### PR TITLE
Update paths for Schwung rename

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md - DJ Deck Module for Move Anything
+# CLAUDE.md - DJ Deck Module for Schwung
 
 ## Overview
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# DJ Deck Module for Move Everything
+# DJ Deck Module for Schwung
 
-Turns an Ableton Move into a standalone CDJ/turntable-style dual-deck DJ player using the [Move Everything](https://github.com/charlesvestal/move-everything) framework.
+Turns an Ableton Move into a standalone CDJ/turntable-style dual-deck DJ player using the [Schwung](https://github.com/charlesvestal/move-everything) framework.
 
 Designed for use with a physical DJ mixer between multiple Moves. Each Move runs two independent decks with timestretch, pitchshift, cue points, loops, stutter effects, slip mode, and BPM sync.
 
@@ -11,7 +11,7 @@ Designed for use with a physical DJ mixer between multiple Moves. Each Move runs
 
 ## Installation
 
-Install [Move Everything](https://github.com/charlesvestal/move-everything-installer) , go to Move Anything settings (shift+touch vol knob+step 2), scroll to Updates, Module Store, Tools, select and click DJ Deck with the data wheel, scroll the data wheel down to Install, and click the data wheel.
+Install [Schwung](https://github.com/charlesvestal/move-everything-installer) , go to Schwung settings (shift+touch vol knob+step 2), scroll to Updates, Module Store, Tools, select and click DJ Deck with the data wheel, scroll the data wheel down to Install, and click the data wheel.
 
 ## Building/Development
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build DJ Deck module for Move Anything (ARM64)
+# Build DJ Deck module for Schwung (ARM64)
 # Copyright (c) 2026 DJ Hard Rich
 # Licensed under CC BY-NC-SA 4.0
 #

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -20,15 +20,15 @@ echo "=== Installing DJ Deck Module ==="
 
 # Deploy to Move - overtake modules go to other/ subdirectory
 echo "Copying module to Move..."
-ssh ableton@move.local "mkdir -p /data/UserData/move-anything/modules/tools/$MODULE_ID"
-scp -r dist/$MODULE_ID/* ableton@move.local:/data/UserData/move-anything/modules/tools/$MODULE_ID/
+ssh ableton@move.local "mkdir -p /data/UserData/schwung/modules/tools/$MODULE_ID"
+scp -r dist/$MODULE_ID/* ableton@move.local:/data/UserData/schwung/modules/tools/$MODULE_ID/
 
 # Set permissions
 echo "Setting permissions..."
-ssh ableton@move.local "chmod -R a+rw /data/UserData/move-anything/modules/tools/$MODULE_ID"
+ssh ableton@move.local "chmod -R a+rw /data/UserData/schwung/modules/tools/$MODULE_ID"
 
 echo ""
 echo "=== Install Complete ==="
-echo "Module installed to: /data/UserData/move-anything/modules/tools/$MODULE_ID/"
+echo "Module installed to: /data/UserData/schwung/modules/tools/$MODULE_ID/"
 echo ""
-echo "Restart Move Anything to load the new module."
+echo "Restart Schwung to load the new module."

--- a/src/dsp/dj_plugin.cpp
+++ b/src/dsp/dj_plugin.cpp
@@ -1,5 +1,5 @@
 /*
- * dj_plugin.cpp - Dual-Deck DJ DSP plugin for Move Anything
+ * dj_plugin.cpp - Dual-Deck DJ DSP plugin for Schwung
  * Copyright (c) 2026 DJ Hard Rich
  * Licensed under CC BY-NC-SA 4.0
  *
@@ -371,7 +371,7 @@ static void host_log(const char *fmt, ...) {
     va_end(ap);
     if (s_host && s_host->log) s_host->log(buf);
     if (!s_logfile)
-        s_logfile = fopen("/data/UserData/move-anything/dj_debug.log", "w");
+        s_logfile = fopen("/data/UserData/schwung/dj_debug.log", "w");
     if (s_logfile) { fprintf(s_logfile, "%s\n", buf); fflush(s_logfile); }
 }
 
@@ -1274,7 +1274,7 @@ static void compute_waveform(uint8_t *out, track_t *tracks, int max_frames) {
 /*  Per-song cue persistence                                          */
 /* ------------------------------------------------------------------ */
 
-static const char *CUE_DIR = "/data/UserData/move-anything/dj_cues";
+static const char *CUE_DIR = "/data/UserData/schwung/dj_cues";
 
 static void cue_file_path(char *out, size_t out_len, const char *song_path) {
     unsigned long hash = 5381;
@@ -2248,7 +2248,7 @@ static void dj_set_param(void *ptr, const char *key, const char *val) {
 /*  Playlist directory scanner                                        */
 /* ------------------------------------------------------------------ */
 
-static const char *PLAYLIST_DIR = "/data/UserData/move-anything/dj_playlists";
+static const char *PLAYLIST_DIR = "/data/UserData/schwung/dj_playlists";
 static const int MAX_PLAYLISTS = 32;
 static const int MAX_PLAYLIST_TRACKS = 256;
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -16,7 +16,7 @@
 import * as os from 'os';
 
 import { setButtonLED, setLED, clearAllLEDs, decodeDelta,
-         shouldFilterMessage } from '/data/UserData/move-anything/shared/input_filter.mjs';
+         shouldFilterMessage } from '/data/UserData/schwung/shared/input_filter.mjs';
 import { MoveBack, MovePlay, MoveShift, MoveRec,
          MoveMainKnob, MoveMainButton, MoveMaster,
          MoveRow1, MoveRow2, MoveRow3, MoveRow4,
@@ -26,8 +26,8 @@ import { MoveBack, MovePlay, MoveShift, MoveRec,
          MoveKnob5Touch, MoveKnob6Touch, MoveKnob7Touch, MoveKnob8Touch,
          White, Black, BrightRed, BrightGreen, OrangeRed, Cyan,
          DarkGrey, WhiteLedDim, WhiteLedBright
-         } from '/data/UserData/move-anything/shared/constants.mjs';
-import { drawMenuHeader } from '/data/UserData/move-anything/shared/menu_layout.mjs';
+         } from '/data/UserData/schwung/shared/constants.mjs';
+import { drawMenuHeader } from '/data/UserData/schwung/shared/menu_layout.mjs';
 
 /* ============================================================================
  * Constants


### PR DESCRIPTION
## Summary

The Move Everything / Move Anything project has been renamed to **Schwung**. This PR updates:

- Import and deploy paths from `/data/UserData/move-anything/` → `/data/UserData/schwung/`
- Brand name references

## Urgency

**Not urgent.** The Schwung installer creates a backwards-compat symlink (`/data/UserData/move-anything` → `/data/UserData/schwung`), so the old paths continue to work. This is strictly housekeeping.

You may also want to rename your repo at some point (GitHub will auto-redirect the old name).

🤖 Generated with [Claude Code](https://claude.com/claude-code)